### PR TITLE
Bugfix for Taektiek/flask-forecast-viewer

### DIFF
--- a/buienradar_forecast_scraper.py
+++ b/buienradar_forecast_scraper.py
@@ -11,9 +11,9 @@ class ForecastSnapper():
         self.url = 'https://forecast.buienradar.nl/2.0/forecast/2759794'
         self.request_header = headers = {'User-Agent': u'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36            (KHTML, like Gecko) Chrome/32.0.1667.0 Safari/537.36', 'X-Cookies-Accepted': '1'}
         ts = dt.now().strftime('%Y%m%d%H%M')
-        self.file_name = fr'results/forecasts_{ts}.json'
-        self.permanent_file_name = fr'results/forecasts.json'
-        self.zip_file = fr'results/forecasts.zip'
+        self.file_name = fr'resources/forecasts_{ts}.json'
+        self.permanent_file_name = fr'resources/forecasts.json'
+        self.zip_file = fr'resources/forecasts.zip'
 
     def snap_and_store_forecast(self):
         r = requests.get(self.url, headers=self.request_header)

--- a/buienradar_forecast_visualization.py
+++ b/buienradar_forecast_visualization.py
@@ -50,7 +50,7 @@ nl = '\n'
 class ForecastVizualization():
 
     def __init__(self):
-        self.zip_file = fr'results/forecasts.zip'
+        self.zip_file = fr'resources/forecasts.zip'
         # self.zip_file = fr'c:\data\forecasts.zip'
 
     def store_item(self, k, v, day):
@@ -126,7 +126,7 @@ class ForecastVizualization():
         self.set_ticks(ax, df_hm2)
         plt.grid(alpha=.4)
         fig.tight_layout()
-        fig.savefig(rf'results/bu_day_{category}.png')
+        fig.savefig(rf'resources/bu_day_{category}.png')
         # fig.savefig(rf'c:\data\bu_day_{category}.png')
 
 fv = ForecastVizualization()


### PR DESCRIPTION
I changed all the results/ to resources/ in buienradar_forecast_scraper.py and buienradar_forecast_visualization.py because the directory is actually called resources